### PR TITLE
Update to crossfire.cpp

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -156,7 +156,7 @@ void processCrossfireTelemetryFrame()
       for (unsigned int i=0; i<=TX_SNR_INDEX; i++) {
         if (getCrossfireTelemetryValue<1>(3+i, value)) {
           if (i == TX_POWER_INDEX) {
-            static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000 };
+            static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000, 250 };
             value = ((unsigned)value < DIM(power_values) ? power_values[value] : 0);
           }
           processCrossfireTelemetryValue(i, value);


### PR DESCRIPTION
Add support for 250mW @ CF micro. Before using 250mW resultet in 0mW in the telemetry sensors.